### PR TITLE
Add iphoneX safeArea support

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		88C4583019F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */; };
 		A04B0EBF1D6ADE5800FBDC47 /* JSQMessagesVideoThumbnailFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = A04B0EBE1D6ADE5800FBDC47 /* JSQMessagesVideoThumbnailFactory.m */; };
 		BF10D6AA1D062AD10072D215 /* JSQMessagesTypingView.m in Sources */ = {isa = PBXBuildFile; fileRef = BF10D6A91D062AD10072D215 /* JSQMessagesTypingView.m */; };
+		DC2D065D21B9E7390042BF46 /* JSQMessagesInputToolbar+SafeArea.h in Sources */ = {isa = PBXBuildFile; fileRef = DC2D065C21B9E7390042BF46 /* JSQMessagesInputToolbar+SafeArea.h */; };
+		DC2D065F21B9E7720042BF46 /* JSQMessagesInputToolbar+SafeArea.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2D065E21B9E7720042BF46 /* JSQMessagesInputToolbar+SafeArea.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -274,6 +276,8 @@
 		A04B0EBE1D6ADE5800FBDC47 /* JSQMessagesVideoThumbnailFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesVideoThumbnailFactory.m; sourceTree = "<group>"; };
 		BF10D6A81D062AD10072D215 /* JSQMessagesTypingView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesTypingView.h; sourceTree = "<group>"; };
 		BF10D6A91D062AD10072D215 /* JSQMessagesTypingView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesTypingView.m; sourceTree = "<group>"; };
+		DC2D065C21B9E7390042BF46 /* JSQMessagesInputToolbar+SafeArea.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JSQMessagesInputToolbar+SafeArea.h"; sourceTree = "<group>"; };
+		DC2D065E21B9E7720042BF46 /* JSQMessagesInputToolbar+SafeArea.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "JSQMessagesInputToolbar+SafeArea.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -437,6 +441,8 @@
 				88A25F6219D8E01A00924534 /* JSQMessagesViewController.h */,
 				88A25F6319D8E01A00924534 /* JSQMessagesViewController.m */,
 				88A25F6419D8E01A00924534 /* JSQMessagesViewController.xib */,
+				DC2D065C21B9E7390042BF46 /* JSQMessagesInputToolbar+SafeArea.h */,
+				DC2D065E21B9E7720042BF46 /* JSQMessagesInputToolbar+SafeArea.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -757,6 +763,7 @@
 				88A25FD519D8E01A00924534 /* JSQMessagesToolbarContentView.m in Sources */,
 				88A25FC119D8E01A00924534 /* JSQMessagesCollectionViewFlowLayout.m in Sources */,
 				8885734A19DE540400E89D20 /* DemoSettingsViewController.m in Sources */,
+				DC2D065D21B9E7390042BF46 /* JSQMessagesInputToolbar+SafeArea.h in Sources */,
 				88A25FC719D8E01A00924534 /* JSQMessagesBubbleImage.m in Sources */,
 				88A25FC519D8E01A00924534 /* JSQMessage.m in Sources */,
 				88A25FD719D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.m in Sources */,
@@ -772,6 +779,7 @@
 				88B5C41F1B7C422900EC79D4 /* JSQMessagesBubblesSizeCalculator.m in Sources */,
 				BF10D6AA1D062AD10072D215 /* JSQMessagesTypingView.m in Sources */,
 				88A25FB619D8E01A00924534 /* NSString+JSQMessages.m in Sources */,
+				DC2D065F21B9E7720042BF46 /* JSQMessagesInputToolbar+SafeArea.m in Sources */,
 				88A901B619F618B100F99777 /* JSQMediaItem.m in Sources */,
 				88A25FCC19D8E01A00924534 /* JSQMessagesCollectionViewCellIncoming.m in Sources */,
 				88A25FBE19D8E01A00924534 /* JSQMessagesBubbleImageFactory.m in Sources */,

--- a/JSQMessagesViewController/Controllers/JSQMessagesInputToolbar+SafeArea.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesInputToolbar+SafeArea.h
@@ -1,0 +1,12 @@
+//
+//  JSQMessagesInputToolbar+SafeArea.h
+//  PeerRate
+//
+
+#import <JSQMessagesViewController/JSQMessagesViewController.h>
+
+@interface JSQMessagesInputToolbar (SafeArea)
+
+- (void)didMoveToWindow;
+
+@end

--- a/JSQMessagesViewController/Controllers/JSQMessagesInputToolbar+SafeArea.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesInputToolbar+SafeArea.m
@@ -1,0 +1,20 @@
+//
+//  JSQMessagesInputToolbar+SafeArea.m
+//
+
+#import "JSQMessagesInputToolbar+SafeArea.h"
+
+@implementation JSQMessagesInputToolbar (SafeArea)
+
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (@available(iOS 11.0, *)) {
+        UILayoutGuide * _Nonnull safeArea = self.window.safeAreaLayoutGuide;
+        if (safeArea) {
+            NSLayoutYAxisAnchor * _Nonnull bottomAnchor = safeArea.bottomAnchor;
+            [[self bottomAnchor] constraintLessThanOrEqualToSystemSpacingBelowAnchor:bottomAnchor multiplier:1.0].active = YES;
+        }
+    }
+}
+
+@end

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -34,7 +34,7 @@
 #import "NSBundle+JSQMessages.h"
 
 #import <objc/runtime.h>
-
+#import "JSQMessagesInputToolbar.h"
 
 // Fixes rdar://26295020
 // See issue #1247 and Peter Steinberger's comment:


### PR DESCRIPTION
> This library is ⚠️ [deprecated](https://www.jessesquires.com/blog/officially-deprecating-jsqmessagesviewcontroller/) ⚠️ and is **only** accepting pull requests for critical bug fixes. Consider using [MessageKit](https://github.com/MessageKit/MessageKit) for new projects.

## Pull request checklist

- [ ] I understand that this library is ⚠️ [deprecated](https://www.jessesquires.com/blog/officially-deprecating-jsqmessagesviewcontroller/) ⚠️ and is **only** accepting pull requests for critical bug fixes.
- [ ] All tests pass. 
- [ ] Demo project builds and runs.
- [ ] I have resolved merge conflicts.
- [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: ____

#### This fixes issue #

## What's in this pull request?

